### PR TITLE
Added manual brake signal in case a hub gets disconnected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+﻿################################################################################
+# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
+################################################################################
+
+/.vs/slnx.sqlite
+/.vs/MattoControllers/FileContentIndex
+/.vs/MattoControllers/v17/.wsuo

--- a/src/MTC4BT/include/BLEHub.h
+++ b/src/MTC4BT/include/BLEHub.h
@@ -65,6 +65,9 @@ class BLEHub
     // Returns a boolean value indicating whether we are connected to the BLE hub.
     bool IsConnected();
 
+    // Sets
+    void SetConnectCallback(std::function<void(bool)> callback);
+
     // Returns the hub's raw address.
     std::string GetRawAddress();
 
@@ -84,8 +87,12 @@ class BLEHub
     void BlinkLights(int durationInMs);
 
     // If true, immediately sets the current speed for all channels to zero.
+    // If false, releases the manual brake.
+    void SetManualBrake(const bool enabled);
+
+    // If true, immediately sets the current speed for all channels to zero.
     // If false, releases the emergency brake.
-    void EmergencyBrake(const bool enabled);
+    void SetEmergencyBrake(const bool enabled);
 
     // Method used to connect to the BLE hub.
     bool Connect(const uint8_t watchdogTimeOutInTensOfSeconds);
@@ -110,6 +117,10 @@ class BLEHub
     bool attachCharacteristic(NimBLEUUID serviceUUID, NimBLEUUID characteristicUUID);
     bool startDriveTask();
     static void driveTaskImpl(void *);
+    void connected();
+    void disconnected();
+
+    std::function<void(bool)> _onConnectionChangedCallback;
 
     BLEHubConfiguration *_config;
     std::vector<BLEHubChannelController *> _channelControllers;
@@ -119,6 +130,7 @@ class BLEHub
     NimBLEAdvertisedDeviceCallbacks *_advertisedDeviceCallback;
     NimBLEClient *_hub;
     NimBLEClientCallbacks *_clientCallback;
+    bool _mbrake;
     bool _ebrake;
     bool _blinkLights;
     ulong _blinkUntil;

--- a/src/MTC4BT/include/BLELocomotive.h
+++ b/src/MTC4BT/include/BLELocomotive.h
@@ -53,6 +53,12 @@ class BLELocomotive
     // Initialized the hubs inside this loco.
     void initHubs();
 
+    void handleConnectCallback(bool connected);
+
+    // If true, immediately sets the current speed for all channels on all hubs to zero and makes all loco lights blink.
+    // If false, releases the manual brake, returning the loco to normal operations.
+    void setManualBrake(const bool enabled);
+
     // Returns a reference to a hub by its address.
     BLEHub *getHubByAddress(std::string address);
 

--- a/src/MTC4BT/src/BLEClientCallback.cpp
+++ b/src/MTC4BT/src/BLEClientCallback.cpp
@@ -17,7 +17,7 @@ void BLEClientCallback::onConnect(NimBLEClient *client)
          */
         client->updateConnParams(64, 64, 0, 56);
 
-        _hub->_isConnected = true;
+        _hub->connected();
     }
 }
 
@@ -27,9 +27,10 @@ void BLEClientCallback::onDisconnect(NimBLEClient *client)
         log4MC::vlogf(LOG_ERR, "BLE : Disconnected from hub '%s'.", _hub->_config->DeviceAddress->toString().c_str());
 
         _hub->_isDiscovered = false;
-        _hub->_isConnected = false;
+        _hub->disconnected();
 
-        if (_hub->_driveTaskHandle != NULL) {
+        if (_hub->_driveTaskHandle != NULL)
+        {
             vTaskDelete(_hub->_driveTaskHandle);
         }
     }

--- a/src/lib/MController/MCChannelController.cpp
+++ b/src/lib/MController/MCChannelController.cpp
@@ -10,6 +10,8 @@ MCChannelController::MCChannelController(MCChannelConfig *config)
 {
     _config = config;
 
+    // Initially activate manual brake;
+    _mbrake = true;
     _ebrake = false;
     _blinkUntil = 0;
     _minPwrPerc = 0;
@@ -46,9 +48,12 @@ void MCChannelController::SetTargetPwrPerc(int16_t targetPwrPerc)
 
 int16_t MCChannelController::GetCurrentPwrPerc()
 {
-    if (_ebrake) {
-        switch (GetAttachedDevice()) {
-        case DeviceType::Light: {
+    if (_ebrake || _mbrake)
+    {
+        switch (GetAttachedDevice())
+        {
+        case DeviceType::Light:
+        {
             // Force blinking lights (50% when on, 0% when off) when e-brake is enabled.
             return MCLightController::Blink() ? 50 : 0;
         }
@@ -76,7 +81,8 @@ bool MCChannelController::UpdateCurrentPwrPerc()
 {
     unsigned long timeStamp = millis();
 
-    if (_ebrake) {
+    if (_ebrake || _mbrake)
+    {
         // Update of current pwr required (directly to zero), if we're e-braking.
         return true;
     }
@@ -130,6 +136,11 @@ uint8_t MCChannelController::GetAbsCurrentPwrPerc()
 bool MCChannelController::IsDrivingForward()
 {
     return _currentPwrPerc >= 0;
+}
+
+void MCChannelController::ManualBrake(bool enabled)
+{
+    _mbrake = enabled;
 }
 
 void MCChannelController::EmergencyBrake(bool enabled)

--- a/src/lib/MController/MCChannelController.h
+++ b/src/lib/MController/MCChannelController.h
@@ -42,6 +42,9 @@ class MCChannelController
 
     void Blink();
 
+    // Sets the current manual brake status.
+    void ManualBrake(bool enabled);
+
     // Sets the current e-brake status.
     void EmergencyBrake(bool enabled);
 
@@ -58,6 +61,7 @@ class MCChannelController
     // Reference to the configuration of the channel controlled by this channel controller.
     MCChannelConfig *_config;
 
+    bool _mbrake;
     bool _ebrake;
     ulong _blinkUntil;
     unsigned long _lastUpdate = 0;

--- a/src/lib/MController/MCConfiguration.h
+++ b/src/lib/MController/MCConfiguration.h
@@ -4,8 +4,9 @@
 #include <Arduino.h>
 #include <vector>
 
-struct MCConfiguration {
-  public:
+struct MCConfiguration
+{
+public:
     // Controller name.
     const char *ControllerName;
 


### PR DESCRIPTION
This change makes all hubs of a loco go into (manual) brake mode, if one of them fails. 
Once the last hub is connected again the manual brake is lifted.

Behavior while manually braking is identical to when e-braking: All motors are stopped and all lights are flashing.

Also had to re-introduce several imports of \<vector>, because otherwise code wouldn't compile!