### PR TITLE
Add handling for red L9110 motor shield

### DIFF
--- a/src/MTC4PF/conf/default/controller_config.h
+++ b/src/MTC4PF/conf/default/controller_config.h
@@ -73,7 +73,7 @@ MattzoMotorShieldConfiguration* getMattzoMotorShieldConfiguration() {
 
   msConf[0] = (MattzoMotorShieldConfiguration){
       .locoAddress = 1,
-      MOTORSHIELD_TYPE
+      .motorShieldType = MOTORSHIELD_TYPE,
       .L298N_enA = 0,
       .L298N_enB = 0,
       .in1 = D3,

--- a/src/MTC4PF/conf/default/controller_config.h
+++ b/src/MTC4PF/conf/default/controller_config.h
@@ -73,7 +73,7 @@ MattzoMotorShieldConfiguration* getMattzoMotorShieldConfiguration() {
 
   msConf[0] = (MattzoMotorShieldConfiguration){
       .locoAddress = 1,
-      .motorShieldType = MotorShieldType::L9110,
+      MOTORSHIELD_TYPE
       .L298N_enA = 0,
       .L298N_enB = 0,
       .in1 = D3,

--- a/src/MTC4PF/conf/default/controller_config.h
+++ b/src/MTC4PF/conf/default/controller_config.h
@@ -57,8 +57,8 @@ const int NUM_MOTORSHIELDS = 1;
 // - locoAddress: loco that this motor shields is attached to
 // - motorShieldType: motor shield type
 // - L298N_enA, L298N_enB: PWM signal pin for motor A / B, if L298N is used.
-// - in1..in4: pin for motor direction control for motor shields L298N and L9110 (in1: forward motor A, in2: reverse motor A, in3: forward motor B, in4: reverse motor B).
-// - minArduinoPower: minimum power setting for Arduino based motor shields. You might need to adapt this to your specific shield and motor. 200 might be a good value for a start. 
+// - in1..in4: pin for motor direction control for motor shields L298N, L9110 and RED_L9110 (in1: forward motor A, in2: reverse motor A, in3: forward motor B, in4: reverse motor B).
+// - minArduinoPower: minimum power setting for Arduino based motor shields. You might need to adapt this to your specific shield and motor. 200 might be a good value for a start.
 // - maxArduinoPower: maximum power setting for Arduino based motor shields (max. 1023). You might need to adapt this to your specific shield and motor. 400 might be a good value for a start.
 // - configMotorA: turning direction of motor A (1 = forward, -1 = backward, 0 = unused). In case of LEGO IR Receiver 8884, this is the motor connected to the red port.
 // - configMotorB: same for motor B; if IR receiver: blue port
@@ -67,7 +67,7 @@ MattzoMotorShieldConfiguration* getMattzoMotorShieldConfiguration() {
   static MattzoMotorShieldConfiguration msConf[NUM_MOTORSHIELDS];
 
 // Type of motor shield directly wired to the controller.
-// (The different motor shield types are defined in MTC4PF.ino)
+// (The different motor shield types are defined in MTC4PF.h)
 // Set to MotorShieldType::NONE if only virtual motor shields are used!
   const MotorShieldType MOTORSHIELD_TYPE = MotorShieldType::L9110;
 

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_BR01.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_BR01.h
@@ -78,7 +78,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
     msConf[0] = (MattzoMotorShieldConfiguration)
     {
         .locoAddress = 1,
-        .motorShieldType = MotorShieldType::L9110,
+        .motorShieldType = MOTORSHIELD_TYPE,
         .L298N_enA = 0,
         .L298N_enB = 0,
         .in1 = D3,

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_BUS-8W.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_BUS-8W.h
@@ -78,7 +78,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
     msConf[0] = (MattzoMotorShieldConfiguration)
     {
         .locoAddress = 988,
-        .motorShieldType = MotorShieldType::L9110,
+        .motorShieldType = MOTORSHIELD_TYPE,
         .L298N_enA = 0,
         .L298N_enB = 0,
         .in1 = D3,

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_IR_offboard.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_IR_offboard.h
@@ -177,7 +177,7 @@ TTrainLightTriggerConfiguration trainLightTriggerConfiguration[NUM_TRAIN_LIGHT_T
 // ***************************
 
 // Type of motor shield directly wired to the controller.
-// (The different motor shield types are defined in MTC4PF.ino)
+// (The different motor shield types are defined in MTC4PF.h)
 // Set to MotorShieldType::NONE if only virtual motor shields are used!
 const MotorShieldType MOTORSHIELD_TYPE = MotorShieldType::LEGO_IR_8884;
 

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_IR_offboard.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_IR_offboard.h
@@ -75,7 +75,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
 
     msConf[0] = (MattzoMotorShieldConfiguration){
         .locoAddress = 10194,
-        .motorShieldType = MotorShieldType::LEGO_IR_8884,
+        .motorShieldType = MOTORSHIELD_TYPE,
         .minArduinoPower = MIN_ARDUINO_POWER,
         .maxArduinoPower = MAX_ARDUINO_POWER,
         .configMotorA = -1,
@@ -83,7 +83,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
         .irChannel = 0};
     msConf[1] = (MattzoMotorShieldConfiguration){
         .locoAddress = 10219,
-        .motorShieldType = MotorShieldType::LEGO_IR_8884,
+        .motorShieldType = MOTORSHIELD_TYPE,
         .minArduinoPower = MIN_ARDUINO_POWER,
         .maxArduinoPower = MAX_ARDUINO_POWER,
         .configMotorA = -1,

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_IR_onboard_L7938.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_IR_onboard_L7938.h
@@ -71,7 +71,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
 
     msConf[0] = (MattzoMotorShieldConfiguration){
         .locoAddress = 7938,
-        .motorShieldType = MotorShieldType::LEGO_IR_8884,
+        .motorShieldType = MOTORSHIELD_TYPE,
         .L298N_enA = 0,
         .L298N_enB = 0,
         .in1 = 0,

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_IR_onboard_L7938.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_IR_onboard_L7938.h
@@ -59,7 +59,7 @@ const int NUM_MOTORSHIELDS = 1;
 // - locoAddress: loco that this motor shields is attached to
 // - motorShieldType: motor shield type
 // - L298N_enA, L298N_enB: PWM signal pin for motor A / B, if L298N is used.
-// - in1..in4: pin for motor direction control for motor shields L298N and L9110 (in1: forward motor A, in2: reverse motor A, in3: forward motor B, in4: reverse motor B).
+// - in1..in4: pin for motor direction control for motor shields L298N, L9110 and RED_L9110 (in1: forward motor A, in2: reverse motor A, in3: forward motor B, in4: reverse motor B).
 // - minArduinoPower: minimum power setting for Arduino based motor shields. You might need to adapt this to your specific shield and motor. 200 might be a good value for a start. Should be 0 for LEGO IR Receiver 8884.
 // - maxArduinoPower: maximum power setting for Arduino based motor shields (max. 1023). You might need to adapt this to your specific shield and motor. 400 might be a good value for a start.
 // - configMotorA: turning direction of motor A (1 = forward, -1 = backward, 0 = unused). In case of LEGO IR Receiver 8884, this is the motor connected to the red port.

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_METRO1.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_METRO1.h
@@ -72,7 +72,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
     msConf[0] = (MattzoMotorShieldConfiguration)
     {
         .locoAddress = 10001,
-        .motorShieldType = MotorShieldType::L9110,
+        .motorShieldType = MOTORSHIELD_TYPE,
         .L298N_enA = 0,
         .L298N_enB = 0,
         .in1 = D3,

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_METRO2.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_METRO2.h
@@ -72,7 +72,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
     msConf[0] = (MattzoMotorShieldConfiguration)
     {
         .locoAddress = 10001,
-        .motorShieldType = MotorShieldType::L9110,
+        .motorShieldType = MOTORSHIELD_TYPE,
         .L298N_enA = 0,
         .L298N_enB = 0,
         .in1 = D3,

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_SFE1.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_SFE1.h
@@ -71,7 +71,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
 
     msConf[0] = (MattzoMotorShieldConfiguration){
         .locoAddress = 10020,
-        MOTORSHIELD_TYPE
+        .motorShieldType = MOTORSHIELD_TYPE,
         .L298N_enA = 0,
         .L298N_enB = 0,
         .in1 = D1,

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_SFE1.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_SFE1.h
@@ -59,7 +59,7 @@ const int NUM_MOTORSHIELDS = 1;
 // - locoAddress: loco that this motor shields is attached to
 // - motorShieldType: motor shield type
 // - L298N_enA, L298N_enB: PWM signal pin for motor A / B, if L298N is used.
-// - in1..in4: pin for motor direction control for motor shields L298N and L9110 (in1: forward motor A, in2: reverse motor A, in3: forward motor B, in4: reverse motor B).
+// - in1..in4: pin for motor direction control for motor shields L298N, L9110 and RED_L9110 (in1: forward motor A, in2: reverse motor A, in3: forward motor B, in4: reverse motor B).
 // - minArduinoPower: minimum power setting for Arduino based motor shields. You might need to adapt this to your specific shield and motor. 200 might be a good value for a start. Should be 0 for LEGO IR Receiver 8884.
 // - maxArduinoPower: maximum power setting for Arduino based motor shields (max. 1023). You might need to adapt this to your specific shield and motor. 400 might be a good value for a start.
 // - configMotorA: turning direction of motor A (1 = forward, -1 = backward, 0 = unused). In case of LEGO IR Receiver 8884, this is the motor connected to the red port.

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_SFE1.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_SFE1.h
@@ -71,7 +71,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
 
     msConf[0] = (MattzoMotorShieldConfiguration){
         .locoAddress = 10020,
-        .motorShieldType = MotorShieldType::L9110,
+        MOTORSHIELD_TYPE
         .L298N_enA = 0,
         .L298N_enB = 0,
         .in1 = D1,

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_TGV1.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_TGV1.h
@@ -71,7 +71,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
 
     msConf[0] = (MattzoMotorShieldConfiguration){
         .locoAddress = 10233,
-        .motorShieldType = MotorShieldType::L9110,
+        MOTORSHIELD_TYPE
         .L298N_enA = 0,
         .L298N_enB = 0,
         .in1 = D3,

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_TGV1.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_TGV1.h
@@ -71,7 +71,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
 
     msConf[0] = (MattzoMotorShieldConfiguration){
         .locoAddress = 10233,
-        MOTORSHIELD_TYPE
+        .motorShieldType = MOTORSHIELD_TYPE,
         .L298N_enA = 0,
         .L298N_enB = 0,
         .in1 = D3,

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_TGV1.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_TGV1.h
@@ -59,7 +59,7 @@ const int NUM_MOTORSHIELDS = 1;
 // - locoAddress: loco that this motor shields is attached to
 // - motorShieldType: motor shield type
 // - L298N_enA, L298N_enB: PWM signal pin for motor A / B, if L298N is used.
-// - in1..in4: pin for motor direction control for motor shields L298N and L9110 (in1: forward motor A, in2: reverse motor A, in3: forward motor B, in4: reverse motor B).
+// - in1..in4: pin for motor direction control for motor shields L298N, L9110 and RED_L9110 (in1: forward motor A, in2: reverse motor A, in3: forward motor B, in4: reverse motor B).
 // - minArduinoPower: minimum power setting for Arduino based motor shields. You might need to adapt this to your specific shield and motor. 200 might be a good value for a start. Should be 0 for LEGO IR Receiver 8884.
 // - maxArduinoPower: maximum power setting for Arduino based motor shields (max. 1023). You might need to adapt this to your specific shield and motor. 400 might be a good value for a start.
 // - configMotorA: turning direction of motor A (1 = forward, -1 = backward, 0 = unused). In case of LEGO IR Receiver 8884, this is the motor connected to the red port.

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_TGV2.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_TGV2.h
@@ -71,7 +71,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
 
     msConf[0] = (MattzoMotorShieldConfiguration){
         .locoAddress = 10233,
-        .motorShieldType = MotorShieldType::L9110,
+        MOTORSHIELD_TYPE
         .L298N_enA = 0,
         .L298N_enB = 0,
         .in1 = D3,

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_TGV2.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_TGV2.h
@@ -71,7 +71,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
 
     msConf[0] = (MattzoMotorShieldConfiguration){
         .locoAddress = 10233,
-        MOTORSHIELD_TYPE
+        .motorShieldType = MOTORSHIELD_TYPE,
         .L298N_enA = 0,
         .L298N_enB = 0,
         .in1 = D3,

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_TGV2.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_TGV2.h
@@ -59,7 +59,7 @@ const int NUM_MOTORSHIELDS = 1;
 // - locoAddress: loco that this motor shields is attached to
 // - motorShieldType: motor shield type
 // - L298N_enA, L298N_enB: PWM signal pin for motor A / B, if L298N is used.
-// - in1..in4: pin for motor direction control for motor shields L298N and L9110 (in1: forward motor A, in2: reverse motor A, in3: forward motor B, in4: reverse motor B).
+// - in1..in4: pin for motor direction control for motor shields L298N, L9110 and RED_L9110 (in1: forward motor A, in2: reverse motor A, in3: forward motor B, in4: reverse motor B).
 // - minArduinoPower: minimum power setting for Arduino based motor shields. You might need to adapt this to your specific shield and motor. 200 might be a good value for a start. Should be 0 for LEGO IR Receiver 8884.
 // - maxArduinoPower: maximum power setting for Arduino based motor shields (max. 1023). You might need to adapt this to your specific shield and motor. 400 might be a good value for a start.
 // - configMotorA: turning direction of motor A (1 = forward, -1 = backward, 0 = unused). In case of LEGO IR Receiver 8884, this is the motor connected to the red port.

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_V100.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_V100.h
@@ -76,7 +76,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
 
     msConf[0] = (MattzoMotorShieldConfiguration){
         .locoAddress = 100,
-        .motorShieldType = MotorShieldType::L9110,
+        MOTORSHIELD_TYPE
         .L298N_enA = D0,
         .L298N_enB = D1,
         .in1 = D3,

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_V100.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_V100.h
@@ -59,7 +59,7 @@ const int NUM_MOTORSHIELDS = 1;
 // - locoAddress: loco that this motor shields is attached to
 // - motorShieldType: motor shield type
 // - L298N_enA, L298N_enB: PWM signal pin for motor A / B, if L298N is used.
-// - in1..in4: pin for motor direction control for motor shields L298N and L9110 (in1: forward motor A, in2: reverse motor A, in3: forward motor B, in4: reverse motor B).
+// - in1..in4: pin for motor direction control for motor shields L298N, L9110 and RED_L9110 (in1: forward motor A, in2: reverse motor A, in3: forward motor B, in4: reverse motor B).
 // - minArduinoPower: minimum power setting for Arduino based motor shields. You might need to adapt this to your specific shield and motor. 200 might be a good value for a start. Should be 0 for LEGO IR Receiver 8884.
 // - maxArduinoPower: maximum power setting for Arduino based motor shields (max. 1023). You might need to adapt this to your specific shield and motor. 400 might be a good value for a start.
 // - configMotorA: turning direction of motor A (1 = forward, -1 = backward, 0 = unused). In case of LEGO IR Receiver 8884, this is the motor connected to the red port.
@@ -70,7 +70,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
     static MattzoMotorShieldConfiguration msConf[NUM_MOTORSHIELDS];
 
     // Type of motor shield directly wired to the controller.
-    // (The different motor shield types are defined in MTC4PF.ino)
+    // (The different motor shield types are defined in MTC4PF.h)
     // Set to MotorShieldType::NONE if only virtual motor shields are used!
     // const MotorShieldType MOTORSHIELD_TYPE = MotorShieldType::L9110;
 

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_V100.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_V100.h
@@ -76,7 +76,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
 
     msConf[0] = (MattzoMotorShieldConfiguration){
         .locoAddress = 100,
-        MOTORSHIELD_TYPE
+        .motorShieldType = MOTORSHIELD_TYPE,
         .L298N_enA = D0,
         .L298N_enB = D1,
         .in1 = D3,

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_V200.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_V200.h
@@ -76,7 +76,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
 
     msConf[0] = (MattzoMotorShieldConfiguration){
         .locoAddress = 200,
-        .motorShieldType = MotorShieldType::L9110,
+        MOTORSHIELD_TYPE
         .L298N_enA = D0,
         .L298N_enB = D1,
         .in1 = D3,

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_V200.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_V200.h
@@ -59,7 +59,7 @@ const int NUM_MOTORSHIELDS = 1;
 // - locoAddress: loco that this motor shields is attached to
 // - motorShieldType: motor shield type
 // - L298N_enA, L298N_enB: PWM signal pin for motor A / B, if L298N is used.
-// - in1..in4: pin for motor direction control for motor shields L298N and L9110 (in1: forward motor A, in2: reverse motor A, in3: forward motor B, in4: reverse motor B).
+// - in1..in4: pin for motor direction control for motor shields L298N, L9110 and RED_L9110 (in1: forward motor A, in2: reverse motor A, in3: forward motor B, in4: reverse motor B).
 // - minArduinoPower: minimum power setting for Arduino based motor shields. You might need to adapt this to your specific shield and motor. 200 might be a good value for a start. Should be 0 for LEGO IR Receiver 8884.
 // - maxArduinoPower: maximum power setting for Arduino based motor shields (max. 1023). You might need to adapt this to your specific shield and motor. 400 might be a good value for a start.
 // - configMotorA: turning direction of motor A (1 = forward, -1 = backward, 0 = unused). In case of LEGO IR Receiver 8884, this is the motor connected to the red port.
@@ -70,7 +70,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
     static MattzoMotorShieldConfiguration msConf[NUM_MOTORSHIELDS];
 
     // Type of motor shield directly wired to the controller.
-    // (The different motor shield types are defined in MTC4PF.ino)
+    // (The different motor shield types are defined in MTC4PF.h)
     // Set to MotorShieldType::NONE if only virtual motor shields are used!
     const MotorShieldType MOTORSHIELD_TYPE = MotorShieldType::L9110;
 

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_V200.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_V200.h
@@ -76,7 +76,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
 
     msConf[0] = (MattzoMotorShieldConfiguration){
         .locoAddress = 200,
-        MOTORSHIELD_TYPE
+        .motorShieldType = MOTORSHIELD_TYPE,
         .L298N_enA = D0,
         .L298N_enB = D1,
         .in1 = D3,

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_br01.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_br01.h
@@ -78,7 +78,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
     msConf[0] = (MattzoMotorShieldConfiguration)
     {
         .locoAddress = 1,
-        .motorShieldType = MotorShieldType::L9110,
+        .motorShieldType = MOTORSHIELD_TYPE,
         .L298N_enA = 0,
         .L298N_enB = 0,
         .in1 = D3,

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_br52.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_br52.h
@@ -78,7 +78,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
     msConf[0] = (MattzoMotorShieldConfiguration)
     {
         .locoAddress = 52,
-        .motorShieldType = MotorShieldType::L9110,
+        .motorShieldType = MOTORSHIELD_TYPE,
         .L298N_enA = 0,
         .L298N_enB = 0,
         .in1 = D3,

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_mini.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_mini.h
@@ -59,7 +59,7 @@ const int NUM_MOTORSHIELDS = 1;
 // - locoAddress: loco that this motor shields is attached to
 // - motorShieldType: motor shield type
 // - L298N_enA, L298N_enB: PWM signal pin for motor A / B, if L298N is used.
-// - in1..in4: pin for motor direction control for motor shields L298N and L9110 (in1: forward motor A, in2: reverse motor A, in3: forward motor B, in4: reverse motor B).
+// - in1..in4: pin for motor direction control for motor shields L298N, L9110 and RED_L9110 (in1: forward motor A, in2: reverse motor A, in3: forward motor B, in4: reverse motor B).
 // - minArduinoPower: minimum power setting for Arduino based motor shields
 // - maxArduinoPower: maximum power setting for Arduino based motor shields (max. 1023)
 // - configMotorA: turning direction of motor A (1 = forward, -1 = backward, 0 = unused). In case of LEGO IR Receiver 8884, this is the motor connected to the red port.
@@ -70,7 +70,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
     static MattzoMotorShieldConfiguration msConf[NUM_MOTORSHIELDS];
 
     // Type of motor shield directly wired to the controller.
-    // (The different motor shield types are defined in MTC4PF.ino)
+    // (The different motor shield types are defined in MTC4PF.h)
     // Set to MotorShieldType::NONE if only virtual motor shields are used!
     const MotorShieldType MOTORSHIELD_TYPE = MotorShieldType::L9110;
 

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_mini.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_mini.h
@@ -76,7 +76,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
 
     msConf[0] = (MattzoMotorShieldConfiguration){
         .locoAddress = 1,
-        .motorShieldType = MotorShieldType::L9110,
+        MOTORSHIELD_TYPE
         .L298N_enA = 0,
         .L298N_enB = 0,
         .in1 = D3,

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_mini.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_mini.h
@@ -76,7 +76,7 @@ MattzoMotorShieldConfiguration *getMattzoMotorShieldConfiguration()
 
     msConf[0] = (MattzoMotorShieldConfiguration){
         .locoAddress = 1,
-        MOTORSHIELD_TYPE
+        .motorShieldType = MOTORSHIELD_TYPE,
         .L298N_enA = 0,
         .L298N_enB = 0,
         .in1 = D3,

--- a/src/MTC4PF/include/MTC4PF.h
+++ b/src/MTC4PF/include/MTC4PF.h
@@ -22,7 +22,8 @@ enum struct MotorShieldType {
     NONE,
     L298N,
     L9110,
-    LEGO_IR_8884
+    LEGO_IR_8884,
+    RED_L9110
 };
 
 // Min and max useful power for Arduino based motor shields

--- a/src/MTC4PF/include/MTC4PF.h
+++ b/src/MTC4PF/include/MTC4PF.h
@@ -16,7 +16,7 @@
 // ***********************
 
 // MotorShieldType represents the type of the motor shield that is attached to the controller
-// L298N and L9110 are motorshields that are physically connected to the controller
+// L298N, L9110 and RED_L9110 are motorshields that are physically connected to the controller
 // LEGO_IR_8884 is connected via an infrared LED that must be wired to the controller
 enum struct MotorShieldType {
     NONE,

--- a/src/MTC4PF/include/MTC4PF.h
+++ b/src/MTC4PF/include/MTC4PF.h
@@ -28,7 +28,8 @@ enum struct MotorShieldType {
 
 // Min and max useful power for Arduino based motor shields
 const int MIN_ARDUINO_POWER = 0;  // default minimum useful arduino power. May be overwritten in motor shield configuration
-const int MAX_ARDUINO_POWER = 1023; // default maximum arduino power. May be overwritten in motor shield configuration
+const int MAX_ARDUINO_POWER = 255; // default maximum arduino power. May be overwritten in motor shield configuration
+const int ANALOG_WRITE_RANGE = 255;
 
 // Train light types
 enum struct TrainLightType {

--- a/src/MTC4PF/src/main.cpp
+++ b/src/MTC4PF/src/main.cpp
@@ -37,6 +37,9 @@ boolean ebreak = false;
 
 void setup()
 {
+    // explicitly set write range to ensure compatibility with [MIN|MAX]_ARDUINO_POWER
+    analogWriteRange(ANALOG_WRITE_RANGE);
+
     // load config from EEPROM, initialize Wifi, MQTT etc.
     setupMattzoController(false);
 
@@ -347,6 +350,7 @@ void setMotorShieldPower(int motorShieldIndex, int motorPortIndex, int desiredPo
 
     // Motorshield specific constants and variables
     int irPowerLevel = 0; // Power level for the LEGO IR Receiver 8884
+    int invertedDesiredPowerLevel = ANALOG_WRITE_RANGE - desiredPowerLevel; // Power level for RED_L9110
 
     mcLog("setMotorShieldPower() called with msi=" + String(motorShieldIndex) + ", mpi=" + String(motorPortIndex) + ", desiredPower=" + String(desiredPower));
 
@@ -354,31 +358,21 @@ void setMotorShieldPower(int motorShieldIndex, int motorPortIndex, int desiredPo
     case MotorShieldType::RED_L9110:
         // motor shield type RED_L9110 with L9110
         if (motorPortIndex == 0) {
-            if (desiredPowerLevel == 0) {
-                digitalWrite(myMattzoMotorShields[motorShieldIndex]._in1, LOW);
-                digitalWrite(myMattzoMotorShields[motorShieldIndex]._in2, LOW);
+            if (directionIsForward) {
+                digitalWrite(myMattzoMotorShields[motorShieldIndex]._in1, HIGH);
+                analogWrite(myMattzoMotorShields[motorShieldIndex]._in2, (invertedDesiredPowerLevel == 0) ? 1 : invertedDesiredPowerLevel);
             } else {
-                if (directionIsForward) {
-                    digitalWrite(myMattzoMotorShields[motorShieldIndex]._in1, HIGH);
-                    analogWrite(myMattzoMotorShields[motorShieldIndex]._in2, myMattzoMotorShields[motorShieldIndex]._maxArduinoPower - desiredPowerLevel);
-                } else {
-                    digitalWrite(myMattzoMotorShields[motorShieldIndex]._in2, HIGH);
-                    analogWrite(myMattzoMotorShields[motorShieldIndex]._in1, myMattzoMotorShields[motorShieldIndex]._maxArduinoPower - desiredPowerLevel);
-                }
+                digitalWrite(myMattzoMotorShields[motorShieldIndex]._in2, HIGH);
+                analogWrite(myMattzoMotorShields[motorShieldIndex]._in1, (invertedDesiredPowerLevel == 0) ? 1 : invertedDesiredPowerLevel);
             }
         }
         if (motorPortIndex == 1) {
-            if (desiredPowerLevel == 0) {
-                digitalWrite(myMattzoMotorShields[motorShieldIndex]._in3, LOW);
-                digitalWrite(myMattzoMotorShields[motorShieldIndex]._in4, LOW);
+            if (directionIsForward) {
+                digitalWrite(myMattzoMotorShields[motorShieldIndex]._in3, HIGH);
+                analogWrite(myMattzoMotorShields[motorShieldIndex]._in4, (invertedDesiredPowerLevel == 0) ? 1 : invertedDesiredPowerLevel);
             } else {
-                if (directionIsForward) {
-                    digitalWrite(myMattzoMotorShields[motorShieldIndex]._in3, HIGH);
-                    analogWrite(myMattzoMotorShields[motorShieldIndex]._in4, myMattzoMotorShields[motorShieldIndex]._maxArduinoPower - desiredPowerLevel);
-                } else {
-                    digitalWrite(myMattzoMotorShields[motorShieldIndex]._in4, HIGH);
-                    analogWrite(myMattzoMotorShields[motorShieldIndex]._in3, myMattzoMotorShields[motorShieldIndex]._maxArduinoPower - desiredPowerLevel);
-                }
+                digitalWrite(myMattzoMotorShields[motorShieldIndex]._in4, HIGH);
+                analogWrite(myMattzoMotorShields[motorShieldIndex]._in3, (invertedDesiredPowerLevel == 0) ? 1 : invertedDesiredPowerLevel);
             }
         }
         break;

--- a/src/MTC4PF/src/main.cpp
+++ b/src/MTC4PF/src/main.cpp
@@ -68,8 +68,10 @@ void setup()
             pinMode(myMattzoMotorShields[i]._L298N_enA, OUTPUT);
             pinMode(myMattzoMotorShields[i]._L298N_enB, OUTPUT);
             // fall through!
+        case MotorShieldType::RED_L9110:
+            // fall through!
         case MotorShieldType::L9110:
-            // initialize motor pins for L298N (continued) and L9110
+            // initialize motor pins for L298N (continued) and L9110 including RED_L9110
             pinMode(myMattzoMotorShields[i]._in1, OUTPUT);
             pinMode(myMattzoMotorShields[i]._in2, OUTPUT);
             pinMode(myMattzoMotorShields[i]._in3, OUTPUT);
@@ -349,6 +351,38 @@ void setMotorShieldPower(int motorShieldIndex, int motorPortIndex, int desiredPo
     mcLog("setMotorShieldPower() called with msi=" + String(motorShieldIndex) + ", mpi=" + String(motorPortIndex) + ", desiredPower=" + String(desiredPower));
 
     switch (myMattzoMotorShields[motorShieldIndex]._motorShieldType) {
+    case MotorShieldType::RED_L9110:
+        // motor shield type RED_L9110 with L9110
+        if (motorPortIndex == 0) {
+            if (desiredPowerLevel == 0) {
+                digitalWrite(myMattzoMotorShields[motorShieldIndex]._in1, LOW);
+                digitalWrite(myMattzoMotorShields[motorShieldIndex]._in2, LOW);
+            } else {
+                if (directionIsForward) {
+                    digitalWrite(myMattzoMotorShields[motorShieldIndex]._in1, HIGH);
+                    analogWrite(myMattzoMotorShields[motorShieldIndex]._in2, myMattzoMotorShields[motorShieldIndex]._maxArduinoPower - desiredPowerLevel);
+                } else {
+                    digitalWrite(myMattzoMotorShields[motorShieldIndex]._in2, HIGH);
+                    analogWrite(myMattzoMotorShields[motorShieldIndex]._in1, myMattzoMotorShields[motorShieldIndex]._maxArduinoPower - desiredPowerLevel);
+                }
+            }
+        }
+        if (motorPortIndex == 1) {
+            if (desiredPowerLevel == 0) {
+                digitalWrite(myMattzoMotorShields[motorShieldIndex]._in3, LOW);
+                digitalWrite(myMattzoMotorShields[motorShieldIndex]._in4, LOW);
+            } else {
+                if (directionIsForward) {
+                    digitalWrite(myMattzoMotorShields[motorShieldIndex]._in3, HIGH);
+                    analogWrite(myMattzoMotorShields[motorShieldIndex]._in4, myMattzoMotorShields[motorShieldIndex]._maxArduinoPower - desiredPowerLevel);
+                } else {
+                    digitalWrite(myMattzoMotorShields[motorShieldIndex]._in4, HIGH);
+                    analogWrite(myMattzoMotorShields[motorShieldIndex]._in3, myMattzoMotorShields[motorShieldIndex]._maxArduinoPower - desiredPowerLevel);
+                }
+            }
+        }
+        break;
+
     case MotorShieldType::L298N:
         // motor shield type L298N
         // The preferred option to flip direction is to go via HIGH/HIGH on the input pins (set HIGH first, then LOW)


### PR DESCRIPTION
Hi,
after having some bad experiences (quality wise) with the recommended L9110 Motor shields (the blue ones) I ordered some of the red ones. Specifically these: https://botland.de/treiber-fur-schrittmotoren/9820-schrittmotortreiber-l9110-12v-08a-5904422338442.html
I quickly discovered, that they don't work with the MotorShieldType::L9110 so I read through the documentation of the Shield and added the MotorShieldType::RED_L9110 which works fine.
I'm not sure if RED_L9110 is a good naming for that shield, but I had no better idea how to describe the distinction between this and the common L9110 type.
I'm also not super convinced, that I didn't miss a thing, that makes this PR unnecessary.