### PR TITLE
Status led is on before getting wifi connection, off after it is connected

### DIFF
--- a/src/MTC4BT/src/main.cpp
+++ b/src/MTC4BT/src/main.cpp
@@ -94,9 +94,13 @@ void setup()
     controller->Setup(controllerConfig);
     log4MC::info("Setup: Controller configuration completed.");
 
+    controller->setStatusLedInSetup(100); // led on
+
     // Setup and connect to WiFi.
     MattzoWifiClient::Setup(networkConfig->WiFi);
 
+    controller->setStatusLedInSetup(0); // led off
+    
     // Setup MQTT publisher (with a queue that can hold 1000 messages).
     // MattzoMQTTPublisher::Setup(ROCRAIL_COMMAND_QUEUE, MQTT_OUTGOING_QUEUE_LENGTH);
 
@@ -108,7 +112,7 @@ void setup()
     log4MC::vlogf(LOG_INFO, "Setup: Number of locos to discover hubs for: %u", controllerConfig->Locomotives.size());
 
     if (controllerConfig->Locomotives.size() == 0) {
-        log4MC::vlogf(LOG_WARNING, "No locomotives found in the configuration, going into BLE scan mode.");    
+        log4MC::vlogf(LOG_WARNING, "No locomotives found in the configuration, going into BLE scan mode.");
     } else {
         log4MC::vlogf(LOG_INFO, "Setup: Number of locos to discover hubs for: %u", controllerConfig->Locomotives.size());
     }

--- a/src/lib/MController/MController.cpp
+++ b/src/lib/MController/MController.cpp
@@ -97,6 +97,21 @@ void MController::Loop()
     }
 }
 
+/*
+    The controller is not running during setup, but we need a status led
+*/
+void MController::setStatusLedInSetup(int powerPerc)
+{
+    for (MCChannelController *channel : _channelControllers) {
+        if (channel->GetAttachedDevice() == DeviceType::StatusLight) {
+            MCLedBase *led = findLedByPinNumber(channel->GetChannel()->GetAddressAsEspPinNumber());
+            if (led) {
+                led->SetCurrentPwrPerc(powerPerc);
+            }
+        }
+    }
+}
+
 bool MController::GetEmergencyBrake()
 {
     // E-brake is enabled when specifically requested (through MQTT) or when the controller is not connected.

--- a/src/lib/MController/MController.h
+++ b/src/lib/MController/MController.h
@@ -30,6 +30,9 @@ class MController
     // Updates emergency brake based on the current controller connection status and controls leds.
     void Loop();
 
+    // Loop is not running in setup but the led needs to be set to indicate searching for network (or something)
+    void setStatusLedInSetup(int powerPerc);
+
     // Returns a boolean value indicating whether the e-brake flag is currently set or not.
     bool GetEmergencyBrake();
 


### PR DESCRIPTION
The led's are controlled in the MContoller->loop() functions, during setup, this function is not being called, so flashing is not going to work.
Just after the controller is setup, the status led is turned on (if any configured) and after a network connection is setup turned off again.
After that the rest is executed as normal.

The effect is best tested with -DWIRED, with or without an ethernet module and/or wired connected to that module.