### PR TITLE
pr #101 fixed log level and added its level in front of the line

### DIFF
--- a/src/lib/MCNetwork/MCLoggingConfiguration.h
+++ b/src/lib/MCNetwork/MCLoggingConfiguration.h
@@ -6,6 +6,7 @@
 struct MCLoggingConfiguration {
   public:
     std::string MinLevel;
+    int mask;
     MCLoggingSerialConfiguration *Serial;
     MCLoggingSyslogConfiguration *SysLog;
 };

--- a/src/lib/MCNetwork/MCLoggingSerialConfiguration.h
+++ b/src/lib/MCNetwork/MCLoggingSerialConfiguration.h
@@ -3,4 +3,5 @@
 struct MCLoggingSerialConfiguration {
   public:
     bool Enabled;
+    int min_level;
 };

--- a/src/lib/MCNetwork/log4MC.h
+++ b/src/lib/MCNetwork/log4MC.h
@@ -37,6 +37,7 @@ class log4MC
     static void logMessage(uint8_t level, char *message);
     static void setLogMask(uint8_t priMask);
     static uint8_t getLogMask();
+    static const char *levelToText(int level);
 
     static MCLoggingConfiguration *_config;
     static bool _connected;


### PR DESCRIPTION
The log level in net `network_configuration.json` was not honored, so all messages got logged.

This is fixed.

Also you did not see the severity on the logline, this is aslo fixed:

```
[0010] [0] [INFO] BLE : Scanning for 0 hub(s)...
[0012] [1] [WARN] No locomotives found in the configuration, going into BLE scan mode.
```