### PR TITLE
126 incorrect speed handling below vmin

### DIFF
--- a/src/MTC4BT/lib/MController/MCChannelConfig.cpp
+++ b/src/MTC4BT/lib/MController/MCChannelConfig.cpp
@@ -3,8 +3,8 @@
 #include "MCChannelConfig.h"
 
 MCChannelConfig::MCChannelConfig(
-	MCChannel *channel, int pwrIncStep, int pwrDecStep, bool isInverted, int pwr, DeviceType deviceType)
-	: _channel{channel}, _pwrIncStep{pwrIncStep}, _pwrDecStep{pwrDecStep}, _isInverted{isInverted}, _pwr{pwr}, _deviceType{deviceType}
+	MCChannel *channel, bool locoStopImmediately, int pwrIncStep, int pwrDecStep, bool isInverted, int pwr, DeviceType deviceType)
+	: _channel{channel}, _locoStopImmediately{locoStopImmediately}, _pwrIncStep{pwrIncStep}, _pwrDecStep{pwrDecStep}, _isInverted{isInverted}, _pwr{pwr}, _deviceType{deviceType}
 {
 }
 
@@ -35,4 +35,9 @@ int MCChannelConfig::GetPwr()
 DeviceType MCChannelConfig::GetAttachedDeviceType()
 {
 	return _deviceType;
+}
+
+bool MCChannelConfig::getLocoStopImmediately()
+{
+	return _locoStopImmediately;
 }

--- a/src/MTC4BT/lib/MController/MCChannelConfig.h
+++ b/src/MTC4BT/lib/MController/MCChannelConfig.h
@@ -7,7 +7,7 @@
 class MCChannelConfig
 {
   public:
-	MCChannelConfig(MCChannel *channel, int pwrIncStep, int pwrDecStep, bool isInverted, int pinPwr, DeviceType deviceType);
+	MCChannelConfig(MCChannel *channel, bool locoStopImmediately, int pwrIncStep, int pwrDecStep, bool isInverted, int pinPwr, DeviceType deviceType);
 
 	// Returns the channel.
 	MCChannel *GetChannel();
@@ -27,6 +27,8 @@ class MCChannelConfig
 	// Returns the type of device attached to the channel.
 	DeviceType GetAttachedDeviceType();
 
+	bool getLocoStopImmediately();
+
   private:
 	// Type of port.
 	MCChannel *_channel;
@@ -40,6 +42,7 @@ class MCChannelConfig
 	// Boolean value indicating whether the attached device' polarity is inverted.
 	bool _isInverted;
 
+	bool _locoStopImmediately;
 	// Power percentage 0-100.
 	int _pwr;
 

--- a/src/MTC4BT/lib/MController/MCChannelController.cpp
+++ b/src/MTC4BT/lib/MController/MCChannelController.cpp
@@ -92,8 +92,8 @@ bool MCChannelController::UpdateCurrentPwrPerc()
 {
 	unsigned long timeStamp = millis();
 
-	if (_ebrake || _mbrake) {
-		// Update of current pwr required (directly to zero), if we're e-braking.
+	if (_ebrake || _mbrake || _targetPwrPerc == 0) {
+		// Update of current pwr required (directly to zero), if we're e-braking, power is off, or the train shall stop.
 		_currentPwrPerc = 0;
 		return true;
 	}
@@ -133,13 +133,14 @@ bool MCChannelController::UpdateCurrentPwrPerc()
 		return true;
 	}
 
+/*
 	if (abs(newPwrPerc) < _minPwrPerc) {
 		// New pwr is slower than min pwr, force to min pwr or stop immediately (dependent on wether we're accelerating or decelerating).
 		dirMultiplier = newPwrPerc >= 0 ? 1 : -1;
 		_currentPwrPerc = isAccelarating() ? _minPwrPerc * dirMultiplier : 0;
 		return true;
 	}
-
+*/
 	// We haven't reached the target pwr yet.
 	_currentPwrPerc = normalizePwrPerc(newPwrPerc);
 	log4MC::vlogf(LOG_DEBUG, "Current power: %d", _currentPwrPerc);

--- a/src/MTC4BT/lib/MController/MCChannelController.cpp
+++ b/src/MTC4BT/lib/MController/MCChannelController.cpp
@@ -92,8 +92,15 @@ bool MCChannelController::UpdateCurrentPwrPerc()
 {
 	unsigned long timeStamp = millis();
 
-	if (_ebrake || _mbrake || _targetPwrPerc == 0) {
+	if (_ebrake || _mbrake) {
 		// Update of current pwr required (directly to zero), if we're e-braking, power is off, or the train shall stop.
+		_currentPwrPerc = 0;
+		return true;
+	}
+
+	// if we send a stop and the config "stopImmediately" in the loco is true, an immediate stop is done,
+	// otherwise it will gradually slow down
+	if (_config->getLocoStopImmediately() && _targetPwrPerc == 0) {
 		_currentPwrPerc = 0;
 		return true;
 	}
@@ -133,14 +140,14 @@ bool MCChannelController::UpdateCurrentPwrPerc()
 		return true;
 	}
 
-/*
-	if (abs(newPwrPerc) < _minPwrPerc) {
-		// New pwr is slower than min pwr, force to min pwr or stop immediately (dependent on wether we're accelerating or decelerating).
-		dirMultiplier = newPwrPerc >= 0 ? 1 : -1;
-		_currentPwrPerc = isAccelarating() ? _minPwrPerc * dirMultiplier : 0;
-		return true;
-	}
-*/
+	/*
+		if (abs(newPwrPerc) < _minPwrPerc) {
+			// New pwr is slower than min pwr, force to min pwr or stop immediately (dependent on wether we're accelerating or decelerating).
+			dirMultiplier = newPwrPerc >= 0 ? 1 : -1;
+			_currentPwrPerc = isAccelarating() ? _minPwrPerc * dirMultiplier : 0;
+			return true;
+		}
+	*/
 	// We haven't reached the target pwr yet.
 	_currentPwrPerc = normalizePwrPerc(newPwrPerc);
 	log4MC::vlogf(LOG_DEBUG, "Current power: %d", _currentPwrPerc);

--- a/src/MTC4BT/src/BLELocomotiveDeserializer.cpp
+++ b/src/MTC4BT/src/BLELocomotiveDeserializer.cpp
@@ -9,6 +9,7 @@ BLELocomotiveConfiguration *BLELocomotiveDeserializer::Deserialize(JsonObject lo
 	const std::string name = locoConfig["name"]; // | "loco_" + locoConfig["address"];
 	int16_t locoPwrIncStep = locoConfig["pwrIncStep"] | defaultPwrIncStep;
 	int16_t locoPwrDecStep = locoConfig["pwrDecStep"] | defaultPwrDecStep;
+	bool locoStopImmediately = locoConfig["stopImmediately"] | true;
 
 	// Iterate over hub configs and copy values from the JsonDocument to BLEHubConfiguration objects.
 	std::vector<BLEHubConfiguration *> hubs;
@@ -55,7 +56,7 @@ BLELocomotiveConfiguration *BLELocomotiveDeserializer::Deserialize(JsonObject lo
 				attachedDevice = "light";
 			}
 
-			channels.push_back(new MCChannelConfig(hubChannel, chnlPwrIncStep, chnlPwrDecStep, isInverted, chnlPwr, deviceTypeMap()[attachedDevice]));
+			channels.push_back(new MCChannelConfig(hubChannel, locoStopImmediately,chnlPwrIncStep, chnlPwrDecStep, isInverted, chnlPwr, deviceTypeMap()[attachedDevice]));
 		}
 
 		hubs.push_back(new BLEHubConfiguration(bleHubTypeMap()[hubType], address, channels, buwizzPowerMap()[powerlevel]));

--- a/src/MTC4BT/src/BLERemoteDeserializer.cpp
+++ b/src/MTC4BT/src/BLERemoteDeserializer.cpp
@@ -49,7 +49,7 @@ BLERemoteConfiguration *BLERemoteDeserializer::Deserialize(JsonObject remoteConf
 	MCChannel *hubChannel = new MCChannel(ChannelType::BleHubChannel, "LED");
 	hubChannel->SetParentAddress(address);
 	std::string attachedDevice = "light";
-	channels.push_back(new MCChannelConfig(hubChannel, hubPwrIncStep, hubPwrDecStep, false, 100, deviceTypeMap()[attachedDevice]));
+	channels.push_back(new MCChannelConfig(hubChannel, false, hubPwrIncStep, hubPwrDecStep, false, 100, deviceTypeMap()[attachedDevice]));
 
 	JsonArray freeConfigs;
 	JsonArray buttonConfigs;

--- a/src/MTC4BT/src/MTC4BTMQTTHandler.cpp
+++ b/src/MTC4BT/src/MTC4BTMQTTHandler.cpp
@@ -179,11 +179,13 @@ void MTC4BTMQTTHandler::handleLc(const char *message)
 		return;
 	}
 
+/*
 	if (speed != 0 && speed < minSpeed) {
 		// Requested speed is too low, we should ignore this command.
 		log4MC::vlogf(LOG_DEBUG, "MQTT: Received and ignored 'lc' command, because speed (%u) was below V_min (%u).", speed, minSpeed);
 		return;
 	}
+*/
 
 	// Get max speed.
 	int maxSpeed;

--- a/src/MTC4BT/src/loadControllerConfiguration.h
+++ b/src/MTC4BT/src/loadControllerConfiguration.h
@@ -43,7 +43,7 @@ MTC4BTConfiguration *loadControllerConfiguration(const char *configFilePath)
 		const std::string attachedDevice = espPinConfig["attachedDevice"] | "nothing";
 
 		MCChannel *espChannel = new MCChannel(ChannelType::EspPinChannel, address);
-		config->EspPins.push_back(new MCChannelConfig(espChannel, pinPwrIncStep, pinPwrDecStep, isInverted, pinPwr, deviceTypeMap()[attachedDevice]));
+		config->EspPins.push_back(new MCChannelConfig(espChannel, false, pinPwrIncStep, pinPwrDecStep, isInverted, pinPwr, deviceTypeMap()[attachedDevice]));
 	}
 	log4MC::vlogf(LOG_INFO, "Config: Read ESP pin configuration (%u).", config->EspPins.size());
 

--- a/src/MTC4PF/conf/examples/MTC4PF_conf_L7938.h
+++ b/src/MTC4PF/conf/examples/MTC4PF_conf_L7938.h
@@ -420,7 +420,7 @@ TTrainLightTriggerConfiguration trainLightTriggerConfiguration[NUM_TRAIN_LIGHT_T
 
     // this section may be commented out to prevent the head and rear lights from being switched off upon stop
     // stop: all exterior lights off. front and rear lights off
-    {
+/*  {
         // head lights red off
         .locoAddress = 7938,
         .lightEventType = LightEventType::STOP,
@@ -455,6 +455,7 @@ TTrainLightTriggerConfiguration trainLightTriggerConfiguration[NUM_TRAIN_LIGHT_T
         .trainLightIndex = 6,
         .trainLightStatus = TrainLightStatus::OFF
 	},
+*/
 };
 
 // ***************************


### PR DESCRIPTION
As described in #126, this fixes the incorrect speed handling below v_min in the MTC4BT.

Some reasons for this change:
- more realistic low speed behaviour
- less clicks on the remote until something happens.
- better stopping behaviour
- precise stops possible with the remote
- more fun

A minir change in a MTC4PF example config file also sneaked into the PR, because I didn't push the develop branch before creating the PR. You never stop learning. :-)