### PR TITLE
Allow uppercase mac addresses and map a name to an address

### DIFF
--- a/src/MTC4BT/include/BLELocomotiveDeserializer.h
+++ b/src/MTC4BT/include/BLELocomotiveDeserializer.h
@@ -2,11 +2,12 @@
 
 #include "MTC4BTConfiguration.h"
 #include "log4MC.h"
+#include "processAddress.h"
 #include <ArduinoJson.h>
 
 class BLELocomotiveDeserializer
 {
   public:
 	// Reads a loco configuration JSON document of max. 4k.
-	static BLELocomotiveConfiguration *Deserialize(JsonObject locoConfig, std::vector<MCChannelConfig *> espPins, int16_t defaultPwrIncStep, int16_t defaultPwrDecStep);
+	static BLELocomotiveConfiguration *Deserialize(JsonObject locoConfig, std::vector<MCChannelConfig *> espPins, int16_t defaultPwrIncStep, int16_t defaultPwrDecStep, processAddress *processor);
 };

--- a/src/MTC4BT/include/BLERemoteDeserializer.h
+++ b/src/MTC4BT/include/BLERemoteDeserializer.h
@@ -3,11 +3,12 @@
 #include "BLERemoteConfiguration.h"
 #include "MTC4BTConfiguration.h"
 #include "log4MC.h"
+#include "processAddress.h"
 #include <ArduinoJson.h>
 
 class BLERemoteDeserializer
 {
   public:
 	// Reads a loco configuration JSON document of max. 4k.
-	static BLERemoteConfiguration *Deserialize(JsonObject remoteConfig, int16_t defaultPwrIncStep, int16_t defaultPwrDecStep);
+	static BLERemoteConfiguration *Deserialize(JsonObject remoteConfig, int16_t defaultPwrIncStep, int16_t defaultPwrDecStep, processAddress *processor);
 };

--- a/src/MTC4BT/include/processAddress.h
+++ b/src/MTC4BT/include/processAddress.h
@@ -1,10 +1,19 @@
 #pragma once
 
 #include <string>
+#include <map>
+
+typedef struct {
+    std::string name;
+    std::string value;
+} LUT;
 
 class processAddress
 {
   public:
 	processAddress(const char *configFilePath);
 	std::string process(const std::string inStr);
+
+  protected:
+    std::map<std::string, std::string> lut;
 };

--- a/src/MTC4BT/include/processAddress.h
+++ b/src/MTC4BT/include/processAddress.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+
+class processAddress
+{
+  public:
+	processAddress(const char *configFilePath);
+	std::string process(const std::string inStr);
+};

--- a/src/MTC4BT/src/BLERemoteDeserializer.cpp
+++ b/src/MTC4BT/src/BLERemoteDeserializer.cpp
@@ -22,7 +22,7 @@ struct remoteModeMap : public std::map<std::string, remoteModes> {
 	~remoteModeMap() {}
 };
 
-BLERemoteConfiguration *BLERemoteDeserializer::Deserialize(JsonObject remoteConfig, int16_t defaultPwrIncStep, int16_t defaultPwrDecStep)
+BLERemoteConfiguration *BLERemoteDeserializer::Deserialize(JsonObject remoteConfig, int16_t defaultPwrIncStep, int16_t defaultPwrDecStep, processAddress * processor)
 {
 	log4MC::debug("Starting reading remotes json");
 
@@ -31,7 +31,7 @@ BLERemoteConfiguration *BLERemoteDeserializer::Deserialize(JsonObject remoteConf
 
 	//  Read hub specific properties.
 	const std::string hubType = remoteConfig["type"];
-	const std::string address = remoteConfig["address"];
+	const std::string address = processor->process(remoteConfig["address"]);
 	const std::string modeString = remoteConfig["mode"];
 	const std::string remoteColor = remoteConfig["color"] | "green";
 

--- a/src/MTC4BT/src/loadControllerConfiguration.h
+++ b/src/MTC4BT/src/loadControllerConfiguration.h
@@ -2,12 +2,13 @@
 
 #include "BLELocomotiveDeserializer.h"
 #include "BLERemoteDeserializer.h"
+#include "processAddress.h"
 
 #define DEFAULT_CONTROLLER_NAME "MTC4BT"
 #define DEFAULT_PWR_INC_STEP 10
 #define DEFAULT_PWR_DEC_STEP 10
 
-MTC4BTConfiguration *loadControllerConfiguration(const char *configFilePath)
+MTC4BTConfiguration *loadControllerConfiguration(const char *configFilePath, processAddress * processor)
 {
 	// New up a configation object, so we can set its properties.
 	MTC4BTConfiguration *config = new MTC4BTConfiguration();
@@ -57,7 +58,7 @@ MTC4BTConfiguration *loadControllerConfiguration(const char *configFilePath)
 			continue;
 		}
 
-		config->LocoConfigs.push_back(BLELocomotiveDeserializer::Deserialize(locoConfig, config->EspPins, pwrIncStep, pwrDecStep));
+		config->LocoConfigs.push_back(BLELocomotiveDeserializer::Deserialize(locoConfig, config->EspPins, pwrIncStep, pwrDecStep, processor));
 	}
 
 	// Iterate over remote configs and copy values from the JsonDocument to BLERemoteConfiguration objects.
@@ -69,7 +70,7 @@ MTC4BTConfiguration *loadControllerConfiguration(const char *configFilePath)
 			// Skip if loco is not enabled.
 			continue;
 		}
-		deserializedRemoteConfig = BLERemoteDeserializer::Deserialize(remoteConfig, pwrIncStep, pwrDecStep);
+		deserializedRemoteConfig = BLERemoteDeserializer::Deserialize(remoteConfig, pwrIncStep, pwrDecStep, processor);
 		if (deserializedRemoteConfig)
 			config->RemoteConfigs.push_back(deserializedRemoteConfig);
 	}
@@ -90,7 +91,7 @@ MTC4BTConfiguration *loadControllerConfiguration(const char *configFilePath)
 			continue;
 		}
 
-		config->LocoConfigs.push_back(BLELocomotiveDeserializer::Deserialize(locoConfig, config->EspPins, pwrIncStep, pwrDecStep));
+		config->LocoConfigs.push_back(BLELocomotiveDeserializer::Deserialize(locoConfig, config->EspPins, pwrIncStep, pwrDecStep, processor));
 	}
 
 	// Read remote config files.
@@ -108,7 +109,7 @@ MTC4BTConfiguration *loadControllerConfiguration(const char *configFilePath)
 			// Skip if loco is not enabled.
 			continue;
 		}
-		deserializedRemoteConfig = BLERemoteDeserializer::Deserialize(remoteConfig, pwrIncStep, pwrDecStep);
+		deserializedRemoteConfig = BLERemoteDeserializer::Deserialize(remoteConfig, pwrIncStep, pwrDecStep, processor);
 		if (deserializedRemoteConfig)
 			config->RemoteConfigs.push_back(deserializedRemoteConfig);
 	}

--- a/src/MTC4BT/src/main.cpp
+++ b/src/MTC4BT/src/main.cpp
@@ -6,6 +6,8 @@
 #include "MTC4BTMQTTHandler.h"
 #include "log4MC.h"
 
+#include "processAddress.h"
+
 #include "loadControllerConfiguration.h"
 #include "loadNetworkConfiguration.h"
 
@@ -18,6 +20,7 @@ MTC4BTConfiguration *controllerConfig;
 
 #define NETWORK_CONFIG_FILE "/network_config.json"
 #define CONTROLLER_CONFIG_FILE "/controller_config.json"
+#define LOOKUPTABLE_CONFIG_FILE "/lookuptabel_config.json"
 
 WiFiClient wifiClient;
 PubSubClient client(wifiClient);
@@ -242,9 +245,12 @@ void setup()
 	// Setup logging (from now on we can use log4MC).
 	log4MC::Setup(networkConfig->hostname.c_str(), networkConfig->Logging);
 
+	// Load optional lookuptable
+	processAddress * processor = new processAddress(LOOKUPTABLE_CONFIG_FILE);
+
 	// Load the controller configuration.
 	log4MC::info("Setup: Loading controller configuration...");
-	controllerConfig = loadControllerConfiguration(CONTROLLER_CONFIG_FILE);
+	controllerConfig = loadControllerConfiguration(CONTROLLER_CONFIG_FILE , processor);
 	controller = new MTC4BTController();
 	controller->Setup(controllerConfig);
 	networkConfig->MQTT->SubscriberName = controllerConfig->ControllerName;

--- a/src/MTC4BT/src/main.cpp
+++ b/src/MTC4BT/src/main.cpp
@@ -20,7 +20,7 @@ MTC4BTConfiguration *controllerConfig;
 
 #define NETWORK_CONFIG_FILE "/network_config.json"
 #define CONTROLLER_CONFIG_FILE "/controller_config.json"
-#define LOOKUPTABLE_CONFIG_FILE "/lookuptabel_config.json"
+#define LOOKUPTABLE_CONFIG_FILE "/lookuptable_config.json"
 
 WiFiClient wifiClient;
 PubSubClient client(wifiClient);

--- a/src/MTC4BT/src/processAddress.cpp
+++ b/src/MTC4BT/src/processAddress.cpp
@@ -1,0 +1,31 @@
+#include "processAddress.h"
+#include "MCJsonConfig.h"
+#include "log4MC.h"
+
+processAddress::processAddress(const char *configFilePath)
+{
+    JsonDocument doc = MCJsonConfig::ReadJsonFile(configFilePath);
+    if (!doc.isNull())
+    {
+        // read the configuration
+        log4MC::debug("Reading lookuptable");
+    } else{
+        log4MC::debug("No lookuptable found, or empty");
+    }
+}
+
+std::string processAddress::process(const std::string inStr)
+{
+	std::string outStr;
+	outStr = inStr; // for now copy the input to the output
+	// as a last action, convert the address to lowercase
+    for (char &c : outStr) {
+        if (c >= 'A' && c <= 'Z') {
+          
+          	// Convert uppercase to lowercase
+          	// by adding 32
+            c += 32;
+        }
+    }
+	return outStr;
+}

--- a/src/MTC4BT/src/processAddress.cpp
+++ b/src/MTC4BT/src/processAddress.cpp
@@ -4,28 +4,43 @@
 
 processAddress::processAddress(const char *configFilePath)
 {
-    JsonDocument doc = MCJsonConfig::ReadJsonFile(configFilePath);
-    if (!doc.isNull())
-    {
-        // read the configuration
-        log4MC::debug("Reading lookuptable");
-    } else{
-        log4MC::debug("No lookuptable found, or empty");
-    }
+	JsonDocument doc = MCJsonConfig::ReadJsonFile(configFilePath);
+	if (!doc.isNull()) {
+		// read the configuration
+		log4MC::debug("Reading lookuptable");
+		JsonArray lookupTable = doc["lookuptable"].as<JsonArray>();
+		for (JsonObject lookupItem : lookupTable) {
+			const std::string name = lookupItem["name"];
+			const std::string address = lookupItem["address"];
+
+			if (lookupItem["name"].is<std::string>() &&
+				lookupItem["address"].is<std::string>()) {
+				// both items are there, add the item to the lookuptable vector
+				lut[name] = address;
+			}
+		}
+
+	} else {
+		log4MC::debug("No lookuptable found, or empty");
+	}
 }
 
 std::string processAddress::process(const std::string inStr)
 {
 	std::string outStr;
-	outStr = inStr; // for now copy the input to the output
+    auto it = lut.find(inStr);
+	if (it != lut.end()) {
+        outStr = it->second;
+	} else {
+		outStr = inStr; // for now copy the input to the output
+	}
 	// as a last action, convert the address to lowercase
-    for (char &c : outStr) {
-        if (c >= 'A' && c <= 'Z') {
-          
-          	// Convert uppercase to lowercase
-          	// by adding 32
-            c += 32;
-        }
-    }
+	for (char &c : outStr) {
+		if (c >= 'A' && c <= 'Z') {
+			// Convert uppercase to lowercase
+			// by adding 32
+			c += 32;
+		}
+	}
 	return outStr;
 }


### PR DESCRIPTION
  - convert upprcase mac addresses to lower case so NimBLE can handle them
  - if `lookuptable_config.json` is pressent it will load it and create a map to map `name` to `address`
  
  ```
  {
    "lookuptable": [
        {
            "name": "50:fa:ab:dd:ee:ff",
            "address": "50:fa:ab:uu:vv:ww"
        },
        {
            "name": "fc:a8:9b:aa:bb:cc",
            "address": "e4:e1:12:xx:yy:zz"
        }
    ]
}
```

This example converts one mac address to an other.